### PR TITLE
Add more debugging tools for the OCaml run-time and code

### DIFF
--- a/mlvalues.py
+++ b/mlvalues.py
@@ -41,6 +41,41 @@
 # Scan OCaml heap region:
 #    ml_scan [/r[N]] addr bytes
 #
+# Validate the OCaml heap:
+#    ml_validate
+# This process can take a while and scans the entire heap, trying to
+# validate all values (e.g. string sizes, overflows, underflows,
+# stray pointers, etc.). Use it to find issues with the garbage
+# collector or OCaml run-time.
+#
+# Show a particular OCaml value, alternative to ml_dump:
+#    ml_show [/r[<N>] <value> [verbosity]
+# Verbosity currently ranges from 0-3, with default being 1.
+# 0: Either type of value or error reason
+# 1: Type and value for simple types
+# 2: Type, value and sub-values for short aggregate/composite types
+#    (Tries not to blow up on your screen)
+# 3: Type, value and sub-values of everything
+# OCaml lists are not detected, a higher recursion depth will
+# be needed to print it out entirely.
+#
+# Show memory address space info with OCaml specific-bits:
+#    ml_target <address|"all"> [verbosity]
+# This command is similar to "info target" but shows OCaml-specifics.
+# Verbosity is only valid for "all", values are 0-2, default is 1:
+# 0: OCaml stack, minor & major heap are displayed
+# 1: Same as 0 and static data, code and known GC metadata areads
+# 2: all memory types are displayed
+# e.g.
+#    ml_target 0x00035208
+#    ml_target all 3
+#
+# Find a particular value in memory:
+#    ml_find <value>
+# Similar to the gdb "find" command, but will also display the memory
+# type (see ml_target) where the value was found, making it easier to
+# find the right occurrence.
+#
 # Use Python class directly for detailed scrutiny, e.g.:
 #    python x = OCamlValue(gdb.parse_and_eval("caml_globals")); print x.size_words()
 #

--- a/mlvalues.py
+++ b/mlvalues.py
@@ -634,6 +634,14 @@ def init_memoryspace(reload=False):
     traceback.print_exc()
     raise
 
+def resolve(address):
+  """Resolve an address to a symbol (function/variable name)."""
+  symbol = gdb.execute("info symbol 0x%08X" % address.cast(size_t), False, True).split(" ",1)[0]
+  if symbol == "No": # FIXME "No symbol matches"
+    return "0x%08X" % address.cast(size_t)
+  else:
+    return "%s" % symbol
+
 # This class represents gdb.Value as OCaml value.
 # Analogue to stdlib Obj module.
 #
@@ -791,11 +799,8 @@ class OCamlValue:
     return n
 
   def resolve(self):
-    symbol = gdb.execute('info symbol ' + str(self.val()),False,True).split(' ',1)[0]
-    if symbol == "No": # FIXME "No symbol matches"
-      return "0x%x" % self.val()
-    else:
-      return "%s" % symbol
+    """Resolve the block pointer contained in this OCamlValue."""
+    return resolve(self.val())
 
   def show_opaque(self,s):
     print "<%s at 0x%x>" % (s,self.val()),

--- a/mlvalues.py
+++ b/mlvalues.py
@@ -1122,3 +1122,28 @@ class ShowMemory(gdb.Command):
 
 ShowMemory()
 
+class FindPointersTo(gdb.Command):
+  """Finds memory locations that point to a specified value:
+     ml_find <value>
+  """
+  def __init__(self):
+    gdb.Command.__init__(self, "ml_find", gdb.COMMAND_DATA, gdb.COMPLETE_SYMBOL, False)
+
+  @TraceAll
+  def invoke(self, arg, from_tty):
+    init_types()
+    init_memoryspace()
+    args = gdb.string_to_argv(arg)
+
+    if len(args) != 1:
+      print("Wrong usage, see \"help ml_find\"")
+      return
+
+    value = int(args[0])
+    pattern = struct.pack("L", value)
+    locations = memoryspace.search_memory_of_types(pattern, *MemoryType.all())
+    for location in locations:
+      memrange = memoryspace.get_range(location)
+      print("Found at 0x%08X in %s" % (location, memrange.description))
+
+FindPointersTo()

--- a/mlvalues.py
+++ b/mlvalues.py
@@ -172,6 +172,10 @@ def try_dereference(gdbval):
   except gdb.MemoryError:
     return None
 
+def print_cont(*args, **kwargs):
+  kwargs["end"] = ''
+  print(*args, **kwargs)
+
 # gdb.Type's used often throughout the script
 intnat = size_t = charp = doublep = heap_chunk_head_p = caml_contextp = caml_thread_structp = None
 
@@ -955,14 +959,14 @@ class OCamlValue:
     return resolve(self.val())
 
   def show_opaque(self,s):
-    print("<%s at 0x%x>" % (s,self.val()))
+    print_cont("<%s at 0x%x>" % (s,self.val()))
 
   def show_seq(self,seq,delim,recurse,raw=False):
     for i, x in enumerate(seq):
       if i:
-        print(delim)
+        print_cont(delim)
       if raw:
-        print(x.resolve())
+        print_cont(x.resolve())
       else:
         x.show(recurse)
 
@@ -1295,34 +1299,34 @@ class OCamlValue:
   @TraceMemoryError
   def show(self,recurse):
       if self.v == 0:
-        print("NULL") # not a value
+        print_cont("NULL") # not a value
       elif self.is_int():
-        print("%d" % self.int())
+        print_cont("%d" % self.int())
       elif self._is_list():
-        print("[")
+        print_cont("[")
         if recurse > 0:
           self.show_seq(self.get_list(), ';', recurse-1)
         else:
-          print("%d values" % self.get_list_length())
-        print("]")
+          print_cont("%d values" % self.get_list_length())
+        print_cont("]")
       else:
         t = self.tag()
         if t == 0:
-          print("(")
+          print_cont("(")
           if recurse > 0:
             self.show_seq(self.fields(), ',', recurse-1)
           else:
-            print("%d fields" % self.size_words())
-          print(")")
+            print_cont("%d fields" % self.size_words())
+          print_cont(")")
         elif t == OCamlValue.LAZY_TAG:
           self.show_opaque("lazy")
         elif t == OCamlValue.CLOSURE_TAG:
-          print("Closure(")
+          print_cont("Closure(")
           if recurse > 0:
             self.show_seq(self.fields(), ',', recurse-1, raw=True)
           else:
-            print("%d fields" % self.size_words())
-          print(")")
+            print_cont("%d fields" % self.size_words())
+          print_cont(")")
         elif t == OCamlValue.OBJECT_TAG:
 #	| x when x = Obj.object_tag ->
 #		let fields = get_fields [] s in
@@ -1341,16 +1345,16 @@ class OCamlValue:
         elif t == OCamlValue.FORWARD_TAG:
           self.show_opaque("forward")
         elif t < OCamlValue.NO_SCAN_TAG:
-          print("Tag%d(" % t)
+          print_cont("Tag%d(" % t)
           if recurse > 0:
             self.show_seq(self.fields(), ',', recurse-1)
           else:
-            print("%d fields" % self.size_words())
-          print(")")
+            print_cont("%d fields" % self.size_words())
+          print_cont(")")
         elif t == OCamlValue.STRING_TAG:
-          print("%s" % self._string())
+          print_cont("%s" % self._string())
         elif t == OCamlValue.DOUBLE_TAG:
-          print("%s" % self._float())
+          print_cont("%s" % self._float())
         elif t == OCamlValue.ABSTRACT_TAG:
           self.show_opaque("abstract")
         elif t == OCamlValue.CUSTOM_TAG:
@@ -1368,7 +1372,7 @@ class OCamlValue:
         elif t == OCamlValue.FINAL_TAG:
           self.show_opaque("final")
         elif t == OCamlValue.DOUBLE_ARRAY_TAG:
-          print("<float array>")
+          print_cont("<float array>")
 #        return "[|%s|]" % "; ".join([x.dump() for x in self.fields()])
         else:
           self.show_opaque("unknown hd=0x%X" % self.hd())
@@ -1398,7 +1402,7 @@ Optional /r flag controls the recursion depth limit."""
       return gdb.parse_and_eval("*((size_t*)&"+addr+")").cast(size_t.pointer())
 
   def show_ptr(self, addr, recurse):
-    print("*0x%x:" % addr.cast(size_t))
+    print_cont("*0x%x:" % addr.cast(size_t))
     OCamlValue(addr.dereference()).show(recurse)
     print("")
 
@@ -1520,7 +1524,7 @@ Optional /r flag controls the recursion depth limit."""
       return gdb.parse_and_eval("*((size_t*)&"+addr+")").cast(size_t.pointer())
 
   def show_val(self, addr, recurse):
-    print("0x%x = " % addr.cast(size_t))
+    print_cont("0x%x = " % addr.cast(size_t))
     OCamlValue(addr).show(recurse)
     print("")
 


### PR DESCRIPTION
This patch series adds a couple more commands to use when debugging OCaml code and especially the OCaml run-time.

This code is best used with the OCaml debug run-time (and debug symbols), yet it should have been hardened to work without them too, albeit without some of the functionality.
Some improvements could be made in the future (e.g. do pointer arithmetic for structures, rather than depending on the type information being available).

Added commands:
ml_target: similar to the gdb 'target' command, yet uses OCaml-specific information about heap/stacks/... to further annotate the provided information.
ml_find: similar to the gdb 'find' command, but also provides extra annotation
ml_validate: validates the OCaml heap contents. This is only useful with a debug run-time with debug symbols.
ml_show: analogous to ml_scan, validates and shows a single OCaml value. Can recurse down references to other values. If used with debug run-time & debug symbols, more validation is possible.
One TODO for this command is the proper interpretation of lists. Without it, each element requires a level of recursion.

Some of the commands have varying levels of verbosity.